### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 ## Introduction
 
-`pylinkedin` is a python package to scrape all details from public linkedin profiles.
- It can also be used as a parser to transform html linkedin profiles into structured json.
+`pylinkedin` is a python package to scrape all details from public LinkedIn profiles.
+ It can also be used as a parser to transform html LinkedIn profiles into structured json.
  
-Some precautions you should take if you want scrape linkedin with python :
+Some precautions you should take if you want scrape LinkedIn with python :
 * Change the default python requests user-agent for a browser user-agent like "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.1 (KHTML, like Gecko) Chrome/22.0.1207.1 Safari/537.1".
-* By default Linkedin has strong anti-scraping policies.
-Linkedin will quickly blacklist ips making unauthentified requests
-from by responding with a non standard http status code `999` to the  http requests. Especially Linkedin banned most ips from cloud providers (Aws, Digital Ocean, ...).
+* By default LinkedIn has strong anti-scraping policies.
+LinkedIn will quickly blacklist ips making unauthentified requests
+from by responding with a non standard http status code `999` to the  http requests. Especially LinkedIn banned most ips from cloud providers (Aws, Digital Ocean, ...).
 * You can use proxies if you want to do concurrent requests but they may also fail a lot.
 
 ## Installation
@@ -27,10 +27,10 @@ Run `pip install git+git://github.com/ericfourrier/scrape-linkedin.git`
 Run `python setup.py install`
 
 ### Tests
-The tests are runs with a html file from a linkedin profile. The main reason is because [Travis](https://travis-ci.org/) use aws machine
+The tests are runs with a html file from a LinkedIn profile. The main reason is because [Travis](https://travis-ci.org/) use aws machine
 and its ips are banned by Linkedin.
 
-Especially the fact that the test suite is passed is not a good indicator than the package will work (Your ip can be banned or linkedin html source code changed).
+Especially the fact that the test suite is passed is not a good indicator than the package will work (Your ip can be banned or LinkedIn html source code changed).
 
 You can still run the test suite at the root of the package with pytest: `py.test test.py`.
 
@@ -62,12 +62,13 @@ It relies on two class:
     c = CustomRequest(list_proxies=[{'https':'http://186.233.94.106:8080',
     'http':'http://186.233.94.106:8080'}]))
 
-`LinkedinItem` is the main class, you can instantiate it with the url or with the response.
+`LinkedinItem` is the main class, you can instantiate it with the URL of public profile using the `url` parameter, or with the HTML contents of the profile page, using `html_string`. See `test.py` for an example of using a save HTML file as input for the scrapper.
 
     from pylinkedin.scraper import LinkedinItem
     l = LinkedinItem(url = 'https://www.linkedin.com/in/kennethreitz')
     l = LinkedinItem(html_string = profile_string)
 
+To use the `html_string`, make sure to browse to the public version of the profile page, as the private version will not work. The private version is the one showing the edit controls next to each section.  
 
 'LinkedinItem' has the folowing syntax the get the info :
 


### PR DESCRIPTION
Added clarification on using the saved LinkedIn HTML as input for the scrapper. If using the private version (the one by default showing to you when logged in), the scrapper will not work.